### PR TITLE
feat: add repositories, database configuration, and integration tests

### DIFF
--- a/src/Spoksy.API/Program.cs
+++ b/src/Spoksy.API/Program.cs
@@ -1,8 +1,13 @@
+using Spoksy.Infrastructure.Configurations;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+string connectionString = builder.Configuration["DB_CONNECTION_STRING"] ?? throw new ArgumentException("Invalid string db conection");
+builder.Services.AddInfrastructure(connectionString);
 
 var app = builder.Build();
 

--- a/src/Spoksy.API/Spoksy.API.csproj
+++ b/src/Spoksy.API/Spoksy.API.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\Spoksy.Infrastructure\Spoksy.Infrastructure.csproj" />
   </ItemGroup>
 
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="dotnet test ..\Spoksy.Test\Spoksy.Test.csproj&#xA;if errorlevel 1 exit 1" />
+  </Target>
+
 </Project>

--- a/src/Spoksy.Domain/Contracts/IChatParticipantRepository.cs
+++ b/src/Spoksy.Domain/Contracts/IChatParticipantRepository.cs
@@ -1,0 +1,11 @@
+using Spoksy.Domain.Entities;
+
+namespace Spoksy.Domain.Contracts
+{
+    public interface IChatParticipantRepository : IGenericRepository<ChatParticipant>
+    {
+        Task<IEnumerable<ChatParticipant>> GetParticipantsByChatAsync(Guid chatId);
+        Task<bool> HasParticipantInChatAsync(Guid chatId, Guid userId);
+        Task<ChatParticipant?> GetParticipantAsync(Guid chatId, Guid userId);
+    }
+} 

--- a/src/Spoksy.Domain/Contracts/IChatRepository.cs
+++ b/src/Spoksy.Domain/Contracts/IChatRepository.cs
@@ -1,0 +1,11 @@
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+
+namespace Spoksy.Domain.Contracts
+{
+    public interface IChatRepository : IGenericRepository<Chat>
+    {
+        Task<IEnumerable<Chat>> GetActiveChatsAsync();
+        Task<IEnumerable<Chat>> GetChatsByLanguageAsync(Language language);
+    }
+} 

--- a/src/Spoksy.Domain/Contracts/IDbConnectionFactory.cs
+++ b/src/Spoksy.Domain/Contracts/IDbConnectionFactory.cs
@@ -1,0 +1,9 @@
+﻿using System.Data;
+
+namespace Spoksy.Domain.Contracts
+{
+    public interface IDbConnectionFactory
+    {
+            IDbConnection CreateConnection();
+    }
+}

--- a/src/Spoksy.Domain/Contracts/IGenericRepository.cs
+++ b/src/Spoksy.Domain/Contracts/IGenericRepository.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq.Expressions;
+using Spoksy.Domain.Entities;
+
+namespace Spoksy.Domain.Contracts
+{
+    public interface IGenericRepository<T> where T : Entity
+    {
+        Task<T> GetByIdAsync(Guid id);
+        Task<IEnumerable<T>> GetAllAsync();
+        Task<IEnumerable<T?>> FindAsync(Expression<Func<T, bool>> predicate);
+        Task AddAsync(T entity);
+        Task UpdateAsync(T entity);
+        Task DeleteAsync(Guid id);
+        Task<bool> ExistsAsync(Guid id);
+    }
+}

--- a/src/Spoksy.Domain/Contracts/IMessageRepository.cs
+++ b/src/Spoksy.Domain/Contracts/IMessageRepository.cs
@@ -1,0 +1,12 @@
+using Spoksy.Domain.Entities;
+
+namespace Spoksy.Domain.Contracts
+{
+    public interface IMessageRepository : IGenericRepository<Message>
+    {
+        Task<IEnumerable<Message>> GetMessagesByChatAsync(Guid chatId);
+        Task<IEnumerable<Message>> GetMessagesByUserAsync(Guid userId);
+        Task<int> GetUnreadMessagesCountAsync(Guid chatId, Guid userId);
+        Task<Message?> GetLastMessageFromChatAsync(Guid chatId);
+    }
+} 

--- a/src/Spoksy.Domain/Contracts/IUnitOfWork.cs
+++ b/src/Spoksy.Domain/Contracts/IUnitOfWork.cs
@@ -1,0 +1,10 @@
+﻿namespace Spoksy.Domain.Contracts
+{
+    public interface IUnitOfWork
+    {
+        Task BeginTransactionAsync();
+        Task<int> CommitAsync();
+        Task RollbackAsync();
+        void Dispose();
+    }
+}

--- a/src/Spoksy.Domain/Contracts/IUserLanguageRepository.cs
+++ b/src/Spoksy.Domain/Contracts/IUserLanguageRepository.cs
@@ -1,0 +1,15 @@
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+
+namespace Spoksy.Domain.Contracts
+{
+    public interface IUserLanguageRepository : IGenericRepository<UserLanguage>
+    {
+        Task<IEnumerable<UserLanguage>> GetUserLanguagesAsync(Guid userId);
+        Task<bool> HasLanguageAsync(Guid userId, Language language);
+        Task<int> CountNativeLanguages(Guid userId);
+        Task<int> CountNonNativeLanguages(Guid userId);
+        Task<bool> HasNativeLanguage(Guid userId);
+        Task<bool> HasNonNativeLanguage(Guid userId);
+    }
+} 

--- a/src/Spoksy.Domain/Contracts/IUserRepository.cs
+++ b/src/Spoksy.Domain/Contracts/IUserRepository.cs
@@ -1,0 +1,10 @@
+using Spoksy.Domain.Entities;
+
+namespace Spoksy.Domain.Contracts
+{
+    public interface IUserRepository : IGenericRepository<User>
+    {
+        Task<User?> GetByEmailAsync(string email);
+        Task<bool> IsEmailUniqueAsync(string email);
+    }
+} 

--- a/src/Spoksy.Domain/Entities/Message.cs
+++ b/src/Spoksy.Domain/Entities/Message.cs
@@ -20,9 +20,9 @@ namespace Spoksy.Domain.Entities{
 
         private const int MAX_MINUTES_TO_DELETE = 15;
 
-        private Message() { } 
+        private Message() { }
 
-        public Message(Guid chatId, Guid senderId, string content, Language? language)
+        public Message(Guid chatId, Guid senderId, string content, Language? language = null)
         {
             if (chatId == Guid.Empty)
                 throw new DomainException("Chat ID cannot be empty");

--- a/src/Spoksy.Domain/ValueObjects/Country.cs
+++ b/src/Spoksy.Domain/ValueObjects/Country.cs
@@ -16,8 +16,9 @@
 
         public static readonly Country UnitedStates = new Country("US", "United States", Language.English, 21);
         public static readonly Country Brazil = new Country("BR", "Brazil", Language.Portuguese, 18);
+        public static readonly Country Spain = new Country("ES", "Spain", Language.Spanish, 18);
 
-        public static readonly List<Country> All = new List<Country>() { UnitedStates, Brazil };
+        public static readonly List<Country> All = new List<Country>() { UnitedStates, Brazil, Spain };
 
         public static Country GetByCode(string code)
         {

--- a/src/Spoksy.Infrastructure/Class1.cs
+++ b/src/Spoksy.Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Spoksy.Infrastructure;
-
-public class Class1
-{
-
-}

--- a/src/Spoksy.Infrastructure/Configurations/ChatConfiguration.cs
+++ b/src/Spoksy.Infrastructure/Configurations/ChatConfiguration.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+
+namespace Spoksy.Infrastructure.Configurations
+{
+    public class ChatConfiguration : IEntityTypeConfiguration<Chat>
+    {
+        public void Configure(EntityTypeBuilder<Chat> builder)
+        {
+            builder.ToTable("chats");
+            
+            builder.HasKey(c => c.Id);
+
+            builder.Property(c => c.CreatedAt)
+                .IsRequired()
+                .HasColumnName("created_At")
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            builder.Property(c => c.LastActivityAt)
+                .IsRequired()
+                .HasColumnName("last_active_at");
+
+            builder.Property(c => c.Status)
+                .IsRequired()
+                .HasColumnName("status")
+                .HasConversion(new EnumToStringConverter<ChatStatus>());
+
+            builder.Property(c => c.PrimaryLanguage)
+                .IsRequired()
+                .HasMaxLength(10)
+                .HasColumnName("primary_language")
+                .HasConversion(
+                   c => c.Code,
+                   c => Language.GetByCode(c)
+                ); ;
+
+            builder.Property(c => c.SecondaryLanguage)
+                .IsRequired()
+                .HasMaxLength(10)
+                .HasColumnName("secondary_language")
+                .HasConversion(
+                   c => c.Code,
+                   c => Language.GetByCode(c)
+                );
+
+            builder.Property(c => c.MaxParticipants)
+                .IsRequired()
+                .HasDefaultValue(2);
+
+            builder.HasMany<ChatParticipant>()
+                .WithOne()
+                .HasForeignKey(cp => cp.ChatId);
+
+        }
+    }
+} 

--- a/src/Spoksy.Infrastructure/Configurations/ChatParticipantConfiguration.cs
+++ b/src/Spoksy.Infrastructure/Configurations/ChatParticipantConfiguration.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Spoksy.Domain.Entities;
+
+namespace Spoksy.Infrastructure.Configurations
+{
+    public class ChatParticipantConfiguration : IEntityTypeConfiguration<ChatParticipant>
+    {
+        public void Configure(EntityTypeBuilder<ChatParticipant> builder)
+        {
+            builder.ToTable("chat_participants"); 
+            
+            builder.HasKey(cp => cp.Id);
+
+            builder.Property(cp => cp.UserId)
+                .IsRequired()
+                .HasColumnName("user_Id");
+
+            builder.Property(cp => cp.ChatId)
+                .IsRequired()
+                .HasColumnName("chat_Id");
+
+            builder.Property(cp => cp.JoinAt)
+                .IsRequired()
+                .HasColumnName("join_at")
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            builder.Property(cp => cp.LeaveAt)
+                .HasColumnName("last_active_at");
+
+            builder.HasIndex(cp => new { cp.ChatId, cp.UserId })
+                .IsUnique();
+
+            builder.HasOne<User>()
+             .WithMany()
+             .HasForeignKey(ul => ul.UserId);
+
+            builder.HasOne<Chat>()
+             .WithMany()
+             .HasForeignKey(ul => ul.ChatId);
+        }
+    }
+} 

--- a/src/Spoksy.Infrastructure/Configurations/DependencyInjection.cs
+++ b/src/Spoksy.Infrastructure/Configurations/DependencyInjection.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Spoksy.Domain.Contracts;
+using Spoksy.Infrastructure.Data;
+using Spoksy.Infrastructure.Repositories;
+
+namespace Spoksy.Infrastructure.Configurations
+{
+    public static class DependencyInjection
+    {
+        public static IServiceCollection AddInfrastructure(this IServiceCollection services, string connectionString)
+        {
+            services.AddDbContext<AppDbContext>(options =>
+                options.UseNpgsql(connectionString));
+
+            // Database Context
+            services.AddScoped<DbContext, AppDbContext>();
+
+            // Unit of Work
+            services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+            // DB Connection Factory
+            services.AddScoped<IDbConnectionFactory>(provider => new AppConnectionFactory(connectionString));
+
+            // Repositories
+            services.AddScoped<IUserRepository, UserRepository>();
+            services.AddScoped<IUserLanguageRepository, UserLanguageRepository>();
+            services.AddScoped<IChatRepository, ChatRepository>();
+            services.AddScoped<IChatParticipantRepository, ChatParticipantRepository>();
+            services.AddScoped<IMessageRepository, MessageRepository>();
+
+            return services;
+        }
+    }
+}

--- a/src/Spoksy.Infrastructure/Configurations/MessageConfiguration.cs
+++ b/src/Spoksy.Infrastructure/Configurations/MessageConfiguration.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Spoksy.Domain.Entities;
+
+namespace Spoksy.Infrastructure.Configurations
+{
+    public class MessageConfiguration : IEntityTypeConfiguration<Message>
+    {
+        public void Configure(EntityTypeBuilder<Message> builder)
+        {
+            builder.ToTable("messages");
+            
+            builder.HasKey(m => m.Id);
+
+            builder.Property(m => m.ChatId)
+                .IsRequired()
+                .HasColumnName("chat_id");
+
+            builder.Property(m => m.SenderId)
+                .IsRequired()
+                .HasColumnName("sender_id");
+
+            builder.Property(m => m.Content)
+                .IsRequired()
+                .HasMaxLength(10000)
+                .HasColumnName("content");
+
+            builder.Property(m => m.SentAt)
+                .IsRequired()
+                .HasColumnName("sent_at")
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            builder.Property(m => m.EditAt)
+                .HasColumnName("edit_at");
+
+            builder.Property(m => m.DeleteAt)
+                .HasColumnName("delete_at");
+
+            builder.Property(m => m.IsRead)
+                .IsRequired()
+                .HasDefaultValue(false)
+                .HasColumnName("is_read");
+
+            builder.Property(m => m.IsEdit)
+                .IsRequired()
+                .HasDefaultValue(false)
+                .HasColumnName("is_edit");
+
+            builder.Property(m => m.IsDelete)
+                .IsRequired()
+                .HasDefaultValue(false)
+                .HasColumnName("is_delete");
+
+        }
+    }
+} 

--- a/src/Spoksy.Infrastructure/Configurations/UserConfiguration.cs
+++ b/src/Spoksy.Infrastructure/Configurations/UserConfiguration.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+
+namespace Spoksy.Infrastructure.Configurations
+{
+    public class UserConfiguration : IEntityTypeConfiguration<User>
+    {
+        public void Configure(EntityTypeBuilder<User> builder)
+        {
+            builder.ToTable("users");
+            
+            builder.HasKey(u => u.Id);
+
+            builder.Property(u => u.Name)
+                .IsRequired()
+                .HasMaxLength(100)
+                .HasColumnName("name");
+
+            builder.Property(u => u.Email)
+                .IsRequired()
+                .HasMaxLength(100)
+                .HasColumnName("email");
+
+            builder.Property(u => u.BirthDate)
+                .IsRequired()
+                .HasColumnName("birth_date");
+
+            builder.Property(u => u.CreatedAt)
+                .IsRequired()
+                .HasColumnName("created_at")
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            builder.Property(u => u.LastActiveAt)
+                .HasColumnName("last_active_at");
+
+            builder.Property(u => u.CurrentCountry)
+               .IsRequired()
+               .HasColumnName("current_country")
+               .HasMaxLength(4)
+               .HasConversion(
+                   v => v.Code, 
+                   v => Country.GetByCode(v) 
+               );
+
+            builder.HasMany<UserLanguage>()
+                .WithOne()
+                .HasForeignKey(ul => ul.UserId);
+
+            builder.HasMany<ChatParticipant>()
+                .WithOne()
+                .HasForeignKey(ul => ul.UserId);
+        }
+    }
+} 

--- a/src/Spoksy.Infrastructure/Configurations/UserLanguageConfiguration.cs
+++ b/src/Spoksy.Infrastructure/Configurations/UserLanguageConfiguration.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+
+namespace Spoksy.Infrastructure.Configurations
+{
+    public class UserLanguageConfiguration : IEntityTypeConfiguration<UserLanguage>
+    {
+        public void Configure(EntityTypeBuilder<UserLanguage> builder)
+        {
+            builder.ToTable("user_languages");
+            
+            builder.HasKey(ul => ul.Id);
+
+            builder.Property(ul => ul.UserId)
+                .IsRequired()
+                .HasColumnName("user_id");
+
+            builder.Property(ul => ul.StartedLearningOn)
+                .IsRequired()
+                .HasColumnName("started_learning_on")
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            builder.Property(ul => ul.ProficiencyLevel)
+                .IsRequired()
+                .HasColumnName("proficiency_level")
+                .HasConversion<string>();
+
+            builder.Property(ul => ul.Language)
+                .IsRequired()
+                .HasMaxLength(10)
+                .HasColumnName("language")
+                .HasConversion(
+                   v => v.Code,
+                   v => Language.GetByCode(v)
+                );
+
+            builder.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(ul => ul.UserId);
+
+        }
+    }
+} 

--- a/src/Spoksy.Infrastructure/Data/AppConnectionFactory.cs
+++ b/src/Spoksy.Infrastructure/Data/AppConnectionFactory.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Configuration;
+using Npgsql;
+using Spoksy.Domain.Contracts;
+using System.Data;
+
+namespace Spoksy.Infrastructure.Data
+{
+    public class AppConnectionFactory : IDbConnectionFactory
+    {
+        private readonly string _connectionString;
+
+        public AppConnectionFactory(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public IDbConnection CreateConnection()
+        {
+            return new NpgsqlConnection(_connectionString);
+        }
+    }
+}

--- a/src/Spoksy.Infrastructure/Data/AppDbContext.cs
+++ b/src/Spoksy.Infrastructure/Data/AppDbContext.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Spoksy.Domain.Entities;
+using System.Reflection;
+
+namespace Spoksy.Infrastructure.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+        public DbSet<UserLanguage> UserLanguages { get; set; }
+        public DbSet<Chat> Chats { get; set; }
+        public DbSet<ChatParticipant> ChatParticipants { get; set; }
+
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSnakeCaseNamingConvention();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Ignore<Spoksy.Domain.ValueObjects.Language>();
+            modelBuilder.Ignore<Spoksy.Domain.ValueObjects.Country>();
+            modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/src/Spoksy.Infrastructure/Repositories/ChatParticipantRepository.cs
+++ b/src/Spoksy.Infrastructure/Repositories/ChatParticipantRepository.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.Contracts;
+
+namespace Spoksy.Infrastructure.Repositories
+{
+    public class ChatParticipantRepository : GenericRepository<ChatParticipant>, IChatParticipantRepository
+    {
+        public ChatParticipantRepository(DbContext context) : base(context)
+        {
+        }
+
+        public async Task<IEnumerable<ChatParticipant>> GetParticipantsByChatAsync(Guid chatId)
+        {
+            return await _dbSet
+                .Where(cp => cp.ChatId == chatId)
+                .ToListAsync();
+        }
+
+        public async Task<bool> HasParticipantInChatAsync(Guid chatId, Guid userId)
+        {
+            return await _dbSet.AnyAsync(cp => 
+                cp.ChatId == chatId && 
+                cp.UserId == userId && 
+                cp.LeaveAt == null);
+        }
+
+        public async Task<ChatParticipant?> GetParticipantAsync(Guid chatId, Guid userId)
+        {
+            return await _dbSet.FirstOrDefaultAsync(cp => 
+                cp.ChatId == chatId && 
+                cp.UserId == userId);
+        }
+
+    }
+} 

--- a/src/Spoksy.Infrastructure/Repositories/ChatRepository.cs
+++ b/src/Spoksy.Infrastructure/Repositories/ChatRepository.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Spoksy.Domain.Contracts;
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+
+namespace Spoksy.Infrastructure.Repositories
+{
+    public class ChatRepository : GenericRepository<Chat>, IChatRepository
+    {
+        public ChatRepository(DbContext context) : base(context)
+        {
+        }
+
+        public async Task<IEnumerable<Chat>> GetActiveChatsAsync()
+        {
+            return await _dbSet
+                .Where(c => c.Status == ChatStatus.Active)
+                .AsNoTracking()
+                 .ToListAsync();
+
+        }
+
+        public async Task<IEnumerable<Chat>> GetChatsByLanguageAsync(Language language)
+        {
+            return await _dbSet
+                .Where(c => c.PrimaryLanguage == language || c.SecondaryLanguage == language)
+                .AsNoTracking()
+                .ToListAsync();
+        }
+    }
+} 

--- a/src/Spoksy.Infrastructure/Repositories/GenericRepository.cs
+++ b/src/Spoksy.Infrastructure/Repositories/GenericRepository.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.Contracts;
+using System.Linq.Expressions;
+
+namespace Spoksy.Infrastructure.Repositories
+{
+    public class GenericRepository<T> : IGenericRepository<T> where T : Entity
+    {
+        protected readonly DbContext _context;
+        protected readonly DbSet<T> _dbSet;
+        public GenericRepository(DbContext context)
+        {
+            _context = context;
+            _dbSet = context.Set<T>();
+        }
+
+        public virtual async Task<T?> GetByIdAsync(Guid id)
+        {
+            return await _dbSet.FindAsync(id);
+        }
+
+        public virtual async Task<IEnumerable<T>> GetAllAsync()
+        {
+            return await _dbSet
+                .AsNoTracking()
+                .ToListAsync();
+        }
+
+        public virtual async Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate)
+        {
+            return await _dbSet
+                .AsNoTracking()
+                .Where(predicate)
+                .ToListAsync();
+        }
+
+        public virtual async Task AddAsync(T entity)
+        {
+            await _dbSet.AddAsync(entity);
+        }
+
+        public virtual async Task UpdateAsync(T entity)
+        {
+            _dbSet.Update(entity);
+        }
+
+        public virtual async Task DeleteAsync(Guid id)
+        {
+            var entity = await GetByIdAsync(id);
+            if (entity != null)
+            {
+                _dbSet.Remove(entity);
+            }
+        }
+
+        public virtual async Task<bool> ExistsAsync(Guid id)
+        {
+            return await _dbSet.FindAsync(id) != null;
+        }
+
+
+    }
+}

--- a/src/Spoksy.Infrastructure/Repositories/MessageRepository.cs
+++ b/src/Spoksy.Infrastructure/Repositories/MessageRepository.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Spoksy.Domain.Contracts;
+using Spoksy.Domain.Entities;
+
+namespace Spoksy.Infrastructure.Repositories
+{
+    public class MessageRepository : GenericRepository<Message>, IMessageRepository
+    {
+        public MessageRepository(DbContext context) : base(context)
+        {
+        }
+
+        public async Task<Message?> GetLastMessageFromChatAsync(Guid chatId)
+        {
+            return await _dbSet
+                .Where(ul => ul.ChatId == chatId)
+                .OrderBy(ul => ul.SentAt)
+                .LastOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<Message>> GetMessagesByChatAsync(Guid chatId)
+        {
+            return await _dbSet
+                .Where(ul => ul.ChatId == chatId)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<Message>> GetMessagesByUserAsync(Guid userId)
+        {
+            return await _dbSet
+                .Where(ul => ul.SenderId == userId)
+                .ToListAsync();
+        }
+
+        public async Task<int> GetUnreadMessagesCountAsync(Guid chatId, Guid userId)
+        {
+            return await _dbSet
+                .Where(ul => ul.ChatId == chatId && ul.SenderId == userId && !ul.IsRead)
+                .CountAsync();
+        }
+
+    }
+}

--- a/src/Spoksy.Infrastructure/Repositories/UnitOfWork.cs
+++ b/src/Spoksy.Infrastructure/Repositories/UnitOfWork.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Spoksy.Domain.Contracts;
+
+namespace Spoksy.Infrastructure.Repositories
+{
+    public class UnitOfWork : IUnitOfWork
+    {
+        private readonly DbContext _context;
+        private IDbContextTransaction _transaction;
+
+        public UnitOfWork(DbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task BeginTransactionAsync()
+        {
+            if (_transaction == null)
+                _transaction = await _context.Database.BeginTransactionAsync();
+        }
+
+        public async Task<int> CommitAsync()
+        {
+            try
+            {
+                int result = await _context.SaveChangesAsync();
+                if (_transaction != null)
+                {
+                    await _transaction.CommitAsync();
+                    await _transaction.DisposeAsync();
+                    _transaction = null;
+                }
+                return result;
+            }
+            catch
+            {
+                if (_transaction != null)
+                {
+                    await _transaction.RollbackAsync();
+                    await _transaction.DisposeAsync();
+                    _transaction = null;
+                }
+                throw;
+            }
+        }
+
+        public async Task RollbackAsync()
+        {
+            if (_transaction != null)
+            {
+                await _transaction.RollbackAsync();
+                await _transaction.DisposeAsync();
+                _transaction = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            _transaction?.Dispose();
+            _context.Dispose();
+        }
+    }
+}

--- a/src/Spoksy.Infrastructure/Repositories/UserLanguageRepository.cs
+++ b/src/Spoksy.Infrastructure/Repositories/UserLanguageRepository.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore;
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.Contracts;
+using Spoksy.Domain.ValueObjects;
+
+namespace Spoksy.Infrastructure.Repositories
+{
+    public class UserLanguageRepository : GenericRepository<UserLanguage>, IUserLanguageRepository
+    {
+        public UserLanguageRepository(DbContext context) : base(context)
+        {
+        }
+
+        public async Task<int> CountNativeLanguages(Guid userId)
+        {
+            return await _dbSet
+                .Where(ul => ul.UserId == userId && ul.ProficiencyLevel == ProficiencyLevel.Native)
+                .CountAsync();
+        }
+
+        public async Task<int> CountNonNativeLanguages(Guid userId)
+        {
+            return await _dbSet
+                .Where(ul => ul.UserId == userId && ul.ProficiencyLevel != ProficiencyLevel.Native)
+                .CountAsync();
+        }
+
+        public async Task<IEnumerable<UserLanguage>> GetUserLanguagesAsync(Guid userId)
+        {
+            return await _dbSet
+                .Where(ul => ul.UserId == userId)
+                .ToListAsync();
+        }
+
+        public async Task<bool> HasLanguageAsync(Guid userId, Language language)
+        {
+            return await _dbSet.AnyAsync(ul => 
+                ul.UserId == userId && 
+                ul.Language == language);
+        }
+
+        public async Task<bool> HasNativeLanguage(Guid userId)
+        {
+            return await _dbSet
+                .Where(ul => ul.UserId == userId && ul.ProficiencyLevel == ProficiencyLevel.Native)
+                .AnyAsync();
+        }
+
+        public async Task<bool> HasNonNativeLanguage(Guid userId)
+        {
+            return await _dbSet
+                .Where(ul => ul.UserId == userId && ul.ProficiencyLevel != ProficiencyLevel.Native)
+                .AnyAsync();
+        }
+    }
+} 

--- a/src/Spoksy.Infrastructure/Repositories/UserRepository.cs
+++ b/src/Spoksy.Infrastructure/Repositories/UserRepository.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.Contracts;
+
+namespace Spoksy.Infrastructure.Repositories
+{
+    public class UserRepository : GenericRepository<User>, IUserRepository
+    {
+        public UserRepository(DbContext context) : base(context)
+        {
+        }
+
+        public async Task<User?> GetByEmailAsync(string email)
+        {
+            return await _dbSet.FirstOrDefaultAsync(u => u.Email == email);
+        }
+
+        public async Task<bool> IsEmailUniqueAsync(string email)
+        {
+            return !await _dbSet.AnyAsync(u => u.Email == email);
+        }
+    }
+}

--- a/src/Spoksy.Infrastructure/Spoksy.Infrastructure.csproj
+++ b/src/Spoksy.Infrastructure/Spoksy.Infrastructure.csproj
@@ -1,6 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+  	<PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+  	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+  	<PackageReference Include="Npgsql" Version="9.0.3" />
+  	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+  </ItemGroup>
+	
+  <ItemGroup>
     <ProjectReference Include="..\Spoksy.Domain\Spoksy.Domain.csproj" />
   </ItemGroup>
 

--- a/src/Spoksy.Test/Infrastructure/IntegrationTestBase.cs
+++ b/src/Spoksy.Test/Infrastructure/IntegrationTestBase.cs
@@ -1,0 +1,41 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Spoksy.Infrastructure.Data;
+using Spoksy.Domain.Contracts;
+using Spoksy.Infrastructure.Repositories;
+
+namespace Spoksy.Test.Infrastructure
+{
+    public abstract class IntegrationTestBase : IAsyncLifetime
+    {
+        private readonly SqliteConnection _connection;
+        protected readonly AppDbContext _context;
+        protected readonly IUnitOfWork _unitOfWork;
+
+        protected IntegrationTestBase()
+        {
+            _connection = new SqliteConnection("DataSource=:memory:");
+            _connection.Open();
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(_connection)
+                .EnableSensitiveDataLogging()
+                .Options;
+
+            _context = new AppDbContext(options);
+            _unitOfWork = new UnitOfWork(_context);
+        }
+
+        public virtual async Task InitializeAsync()
+        {
+            await _context.Database.EnsureCreatedAsync();
+        }
+
+        public virtual async Task DisposeAsync()
+        {
+            await _context.Database.EnsureDeletedAsync();
+            await _context.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+} 

--- a/src/Spoksy.Test/Infrastructure/Repositories/ChatParticipantRepositoryTests.cs
+++ b/src/Spoksy.Test/Infrastructure/Repositories/ChatParticipantRepositoryTests.cs
@@ -1,0 +1,123 @@
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+using Spoksy.Domain.Contracts;
+using Spoksy.Infrastructure.Repositories;
+
+namespace Spoksy.Test.Infrastructure.Repositories
+{
+    public class ChatParticipantRepositoryTests : IntegrationTestBase
+    {
+        private readonly IChatParticipantRepository _chatParticipantRepository;
+        private readonly IChatRepository _chatRepository;
+        private readonly IUserRepository _userRepository;
+
+        public ChatParticipantRepositoryTests() : base()
+        {
+            _chatParticipantRepository = new ChatParticipantRepository(_context);
+            _chatRepository = new ChatRepository(_context);
+            _userRepository = new UserRepository(_context);
+        }
+
+        private async Task<User> CreateTestUser(string name = "Test User", string email = "test@example.com")
+        {
+            var user = new User(
+                name,
+                email,
+                DateTime.UtcNow.AddYears(-25),
+                Country.GetByCode("BR")
+            );
+            await _userRepository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+            return user;
+        }
+
+        private async Task<Chat> CreateTestChat(string name = "Test Chat")
+        {
+            var chat = new Chat(
+                Language.GetByCode("en"),
+                Language.GetByCode("es")
+            );
+            await _chatRepository.AddAsync(chat);
+            await _unitOfWork.CommitAsync();
+            return chat;
+        }
+
+        private ChatParticipant CreateChatParticipant(Guid chatId, Guid userId)
+        {
+            return new ChatParticipant(userId, chatId);
+        }
+
+        [Fact]
+        public async Task GetParticipantsByChatAsync_ShouldReturnAllParticipants()
+        {
+            var chat = await CreateTestChat();
+            var user1 = await CreateTestUser("User1", "user1@example.com");
+            var user2 = await CreateTestUser("User2", "user2@example.com");
+            var participant1 = CreateChatParticipant(chat.Id, user1.Id);
+            var participant2 = CreateChatParticipant(chat.Id, user2.Id);
+            await _chatParticipantRepository.AddAsync(participant1);
+            await _chatParticipantRepository.AddAsync(participant2);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _chatParticipantRepository.GetParticipantsByChatAsync(chat.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            Assert.Contains(result, p => p.UserId == user1.Id);
+            Assert.Contains(result, p => p.UserId == user2.Id);
+        }
+
+        [Fact]
+        public async Task HasParticipantInChatAsync_WithExistingParticipant_ShouldReturnTrue()
+        {
+            var chat = await CreateTestChat();
+            var user = await CreateTestUser();
+            var participant = CreateChatParticipant(chat.Id, user.Id);
+            await _chatParticipantRepository.AddAsync(participant);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _chatParticipantRepository.HasParticipantInChatAsync(chat.Id, user.Id);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task HasParticipantInChatAsync_WithNonExistingParticipant_ShouldReturnFalse()
+        {
+            var chat = await CreateTestChat();
+            var user = await CreateTestUser();
+
+            var result = await _chatParticipantRepository.HasParticipantInChatAsync(chat.Id, user.Id);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task GetParticipantAsync_WithExistingParticipant_ShouldReturnParticipant()
+        {
+            var chat = await CreateTestChat();
+            var user = await CreateTestUser();
+            var participant = CreateChatParticipant(chat.Id, user.Id);
+
+            await _chatParticipantRepository.AddAsync(participant);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _chatParticipantRepository.GetParticipantAsync(chat.Id, user.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(chat.Id, result.ChatId);
+            Assert.Equal(user.Id, result.UserId);
+        }
+
+        [Fact]
+        public async Task GetParticipantAsync_WithNonExistingParticipant_ShouldReturnNull()
+        {
+            var chat = await CreateTestChat();
+            var user = await CreateTestUser();
+
+            var result = await _chatParticipantRepository.GetParticipantAsync(chat.Id, user.Id);
+
+            Assert.Null(result);
+        }
+    }
+} 

--- a/src/Spoksy.Test/Infrastructure/Repositories/ChatRepositoryTests.cs
+++ b/src/Spoksy.Test/Infrastructure/Repositories/ChatRepositoryTests.cs
@@ -1,0 +1,82 @@
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+using Spoksy.Domain.Contracts;
+using Spoksy.Infrastructure.Repositories;
+
+namespace Spoksy.Test.Infrastructure.Repositories
+{
+    public class ChatRepositoryTests : IntegrationTestBase
+    {
+        private readonly IChatRepository _chatRepository;
+
+        public ChatRepositoryTests() : base()
+        {
+            _chatRepository = new ChatRepository(_context);
+        }
+
+        private Chat CreateChat(
+            Language primaryLanguage = null,
+            Language secondaryLanguage = null
+        )
+        {
+            return new Chat(
+                primaryLanguage ?? Language.GetByCode("en"),
+                secondaryLanguage ?? Language.GetByCode("es")
+            );
+        }
+
+        [Fact]
+        public async Task GetActiveChatsAsync_ShouldReturnOnlyActiveChats()
+        {
+            var activeChat1 = CreateChat();
+            var activeChat2 = CreateChat();
+            var inactiveChat = CreateChat();
+            inactiveChat.CloseChat();
+            await _chatRepository.AddAsync(activeChat1);
+            await _chatRepository.AddAsync(activeChat2);
+            await _chatRepository.AddAsync(inactiveChat);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _chatRepository.GetActiveChatsAsync();
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            Assert.All(result, chat => Assert.Equal(ChatStatus.Active, chat.Status));
+            Assert.Contains(result, c => c.Id == activeChat1.Id);
+            Assert.Contains(result, c => c.Id == activeChat2.Id);
+        }
+
+        [Fact]
+        public async Task GetChatsByLanguageAsync_ShouldReturnChatsWithMatchingLanguage()
+        {
+            var language = Language.GetByCode("pt");
+            var chatWithPrimary = CreateChat(primaryLanguage: language);
+            var chatWithSecondary = CreateChat(secondaryLanguage: language);
+            var chatWithoutLanguage = CreateChat();
+            await _chatRepository.AddAsync(chatWithPrimary);
+            await _chatRepository.AddAsync(chatWithSecondary);
+            await _chatRepository.AddAsync(chatWithoutLanguage);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _chatRepository.GetChatsByLanguageAsync(language);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            Assert.Contains(result, c => c.Id == chatWithPrimary.Id);
+            Assert.Contains(result, c => c.Id == chatWithSecondary.Id);
+        }
+
+        [Fact]
+        public async Task GetChatsByLanguageAsync_WithNonExistingLanguage_ShouldReturnEmpty()
+        {
+            var chat = CreateChat();
+            await _chatRepository.AddAsync(chat);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _chatRepository.GetChatsByLanguageAsync(Language.GetByCode("ja"));
+
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+    }
+} 

--- a/src/Spoksy.Test/Infrastructure/Repositories/GenericRepositoryTests.cs
+++ b/src/Spoksy.Test/Infrastructure/Repositories/GenericRepositoryTests.cs
@@ -1,0 +1,157 @@
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.Contracts;
+using Spoksy.Infrastructure.Repositories;
+using Spoksy.Domain.ValueObjects;
+
+namespace Spoksy.Test.Infrastructure.Repositories
+{
+    public class GenericRepositoryTests : IntegrationTestBase
+    {
+        private readonly IGenericRepository<User> _repository;
+
+        public GenericRepositoryTests() : base()
+        {
+            _repository = new GenericRepository<User>(_context);
+        }
+
+        private User CreateUser(string name = "Test")
+        {
+            return new User(
+                name,
+                $"{name.ToLower()}@example.com",
+                DateTime.UtcNow.AddYears(-25),
+                Country.GetByCode("BR")
+            );
+        }
+
+        [Fact]
+        public async Task GetAllAsync_ShouldReturnAllEntities()
+        {
+            var user1 = CreateUser();
+            var user2 = CreateUser("Second");
+            await _repository.AddAsync(user1);
+            await _repository.AddAsync(user2);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _repository.GetAllAsync();
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            Assert.Contains(result, e => e.Id == user1.Id);
+            Assert.Contains(result, e => e.Id == user2.Id);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_WithExistingEntity_ShouldReturnEntity()
+        {
+            var user = CreateUser();
+            await _repository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _repository.GetByIdAsync(user.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(user.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_WithNonExistingEntity_ShouldReturnNull()
+        {
+            var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task AddAsync_ShouldAddEntitySuccessfully()
+        {
+            var user = CreateUser();
+
+            await _repository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            var savedEntity = await _repository.GetByIdAsync(user.Id);
+            Assert.NotNull(savedEntity);
+            Assert.Equal(user.Id, savedEntity.Id);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ShouldUpdateEntitySuccessfully()
+        {
+            var user = CreateUser();
+            await _repository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            user.UpdateName("Updated Name");
+            await _repository.UpdateAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            var updatedEntity = await _repository.GetByIdAsync(user.Id);
+            Assert.NotNull(updatedEntity);
+            Assert.Equal("Updated Name", updatedEntity.Name);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ShouldDeleteEntitySuccessfully()
+        {
+            var user = CreateUser();
+            await _repository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            await _repository.DeleteAsync(user.Id);
+            await _unitOfWork.CommitAsync();
+
+            var deletedEntity = await _repository.GetByIdAsync(user.Id);
+            Assert.Null(deletedEntity);
+        }
+
+        [Fact]
+        public async Task ExistsAsync_WithExistingEntity_ShouldReturnTrue()
+        {
+            var user = CreateUser();
+            await _repository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            var exists = await _repository.ExistsAsync(user.Id);
+
+            Assert.True(exists);
+        }
+
+        [Fact]
+        public async Task ExistsAsync_WithNonExistingEntity_ShouldReturnFalse()
+        {
+            var exists = await _repository.ExistsAsync(Guid.NewGuid());
+
+            Assert.False(exists);
+        }
+
+        [Fact]
+        public async Task FindAsync_WithValidCondition_ShouldReturnEntities()
+        {
+            var user1 = CreateUser();
+            var user2 = CreateUser("Second");
+            await _repository.AddAsync(user1);
+            await _repository.AddAsync(user2);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _repository.FindAsync(x => x.Name == user1.Name);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Contains(result, e => e.Id == user1.Id);
+        }
+
+        [Fact]
+        public async Task FindAsync_WithInvalidCondition_ShouldReturnEmptyList()
+        {
+            var user = CreateUser();
+            await _repository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _repository.FindAsync(x => x.Name == "NonExisting");
+
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+    }
+} 

--- a/src/Spoksy.Test/Infrastructure/Repositories/MessageRepositoryTests.cs
+++ b/src/Spoksy.Test/Infrastructure/Repositories/MessageRepositoryTests.cs
@@ -1,0 +1,142 @@
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+using Spoksy.Domain.Contracts;
+using Spoksy.Infrastructure.Repositories;
+
+namespace Spoksy.Test.Infrastructure.Repositories
+{
+    public class MessageRepositoryTests : IntegrationTestBase
+    {
+        private readonly IMessageRepository _messageRepository;
+        private readonly IChatRepository _chatRepository;
+        private readonly IUserRepository _userRepository;
+
+        public MessageRepositoryTests() : base()
+        {
+            _messageRepository = new MessageRepository(_context);
+            _chatRepository = new ChatRepository(_context);
+            _userRepository = new UserRepository(_context);
+        }
+
+        private async Task<User> CreateTestUser(string name = "Test User", string email = "test@example.com")
+        {
+            var user = new User(
+                name,
+                email,
+                DateTime.UtcNow.AddYears(-25),
+                Country.GetByCode("BR")
+            );
+            await _userRepository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+            return user;
+        }
+
+        private async Task<Chat> CreateTestChat(string name = "Test Chat")
+        {
+            var chat = new Chat(
+                Language.GetByCode("en"),
+                Language.GetByCode("es")
+            );
+            await _chatRepository.AddAsync(chat);
+            await _unitOfWork.CommitAsync();
+            return chat;
+        }
+
+        private Message CreateMessage(
+            Guid chatId,
+            Guid userId,
+            string content = "Test message")
+        {
+            return new Message(chatId, userId, content);
+        }
+
+        [Fact]
+        public async Task GetMessagesByChatAsync_ShouldReturnAllChatMessages()
+        {
+            var chat = await CreateTestChat();
+            var user = await CreateTestUser();
+            var message1 = CreateMessage(chat.Id, user.Id, "First message");
+            var message2 = CreateMessage(chat.Id, user.Id, "Second message");
+            await _messageRepository.AddAsync(message1);
+            await _messageRepository.AddAsync(message2);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _messageRepository.GetMessagesByChatAsync(chat.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            Assert.Contains(result, m => m.Content == "First message");
+            Assert.Contains(result, m => m.Content == "Second message");
+        }
+
+        [Fact]
+        public async Task GetMessagesByUserAsync_ShouldReturnAllUserMessages()
+        {
+            var chat1 = await CreateTestChat("Chat 1");
+            var chat2 = await CreateTestChat("Chat 2");
+            var user = await CreateTestUser();
+            var otherUser = await CreateTestUser("Other User", "other@example.com");
+            var message1 = CreateMessage(chat1.Id, user.Id, "User message 1");
+            var message2 = CreateMessage(chat2.Id, user.Id, "User message 2");
+            var otherMessage = CreateMessage(chat1.Id, otherUser.Id, "Other user message");
+            await _messageRepository.AddAsync(message1);
+            await _messageRepository.AddAsync(message2);
+            await _messageRepository.AddAsync(otherMessage);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _messageRepository.GetMessagesByUserAsync(user.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            Assert.All(result, m => Assert.Equal(user.Id, m.SenderId));
+            Assert.Contains(result, m => m.Content == "User message 1");
+            Assert.Contains(result, m => m.Content == "User message 2");
+        }
+
+        [Fact]
+        public async Task GetUnreadMessagesCountAsync_ShouldReturnCorrectCount()
+        {
+            var chat = await CreateTestChat();
+            var user = await CreateTestUser();
+            var message1 = CreateMessage(chat.Id, user.Id);
+            var message2 = CreateMessage(chat.Id, user.Id);
+            var message3 = CreateMessage(chat.Id, user.Id);
+            message3.SetRead();
+            await _messageRepository.AddAsync(message1);
+            await _messageRepository.AddAsync(message2);
+            await _messageRepository.AddAsync(message3);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _messageRepository.GetUnreadMessagesCountAsync(chat.Id, user.Id);
+
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public async Task GetLastMessageFromChatAsync_ShouldReturnMostRecentMessage()
+        {
+            var chat = await CreateTestChat();
+            var user = await CreateTestUser();
+            var message1 = CreateMessage(chat.Id, user.Id, "First message");
+            var message2 = CreateMessage(chat.Id, user.Id, "Last message");
+            await _messageRepository.AddAsync(message1);
+            await _messageRepository.AddAsync(message2);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _messageRepository.GetLastMessageFromChatAsync(chat.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal("Last message", result.Content);
+        }
+
+        [Fact]
+        public async Task GetLastMessageFromChatAsync_WithNoMessages_ShouldReturnNull()
+        {
+            var chat = await CreateTestChat();
+
+            var result = await _messageRepository.GetLastMessageFromChatAsync(chat.Id);
+
+            Assert.Null(result);
+        }
+    }
+} 

--- a/src/Spoksy.Test/Infrastructure/Repositories/UserLanguageRepositoryTests.cs
+++ b/src/Spoksy.Test/Infrastructure/Repositories/UserLanguageRepositoryTests.cs
@@ -1,0 +1,168 @@
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+using Spoksy.Domain.Contracts;
+using Spoksy.Infrastructure.Repositories;
+
+namespace Spoksy.Test.Infrastructure.Repositories
+{
+    public class UserLanguageRepositoryTests : IntegrationTestBase
+    {
+        private readonly IUserLanguageRepository _userLanguageRepository;
+        private readonly IUserRepository _userRepository;
+
+        public UserLanguageRepositoryTests() : base()
+        {
+            _userLanguageRepository = new UserLanguageRepository(_context);
+            _userRepository = new UserRepository(_context);
+        }
+
+        private async Task<User> CreateTestUser()
+        {
+            var user = new User(
+                "Test User",
+                "test@example.com",
+                DateTime.UtcNow.AddYears(-25),
+                Country.GetByCode("BR")
+            );
+            await _userRepository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+            return user;
+        }
+
+        private UserLanguage CreateUserLanguage(Guid userId, string languageCode = "en", ProficiencyLevel proficiency = ProficiencyLevel.Native)
+        {
+            return new UserLanguage(
+                userId,
+                Language.GetByCode(languageCode),
+                proficiency
+            );
+        }
+
+        [Fact]
+        public async Task GetUserLanguagesAsync_ShouldReturnAllUserLanguages()
+        {
+            var user = await CreateTestUser();
+            var language1 = CreateUserLanguage(user.Id, "en", ProficiencyLevel.Native);
+            var language2 = CreateUserLanguage(user.Id, "es", ProficiencyLevel.Intermediate);
+            await _userLanguageRepository.AddAsync(language1);
+            await _userLanguageRepository.AddAsync(language2);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userLanguageRepository.GetUserLanguagesAsync(user.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            Assert.Contains(result, l => l.Language.Code == "en");
+            Assert.Contains(result, l => l.Language.Code == "es");
+        }
+
+        [Fact]
+        public async Task HasLanguageAsync_WithExistingLanguage_ShouldReturnTrue()
+        {
+            var user = await CreateTestUser();
+            var language = CreateUserLanguage(user.Id, "en");
+            await _userLanguageRepository.AddAsync(language);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userLanguageRepository.HasLanguageAsync(user.Id, Language.English);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task HasLanguageAsync_WithNonExistingLanguage_ShouldReturnFalse()
+        {
+            var user = await CreateTestUser();
+
+            var result = await _userLanguageRepository.HasLanguageAsync(user.Id, Language.English);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task CountNativeLanguages_ShouldReturnCorrectCount()
+        {
+            var user = await CreateTestUser();
+            var language1 = CreateUserLanguage(user.Id, "en", ProficiencyLevel.Native);
+            var language2 = CreateUserLanguage(user.Id, "es", ProficiencyLevel.Native);
+            var language3 = CreateUserLanguage(user.Id, "pt", ProficiencyLevel.Intermediate);
+            await _userLanguageRepository.AddAsync(language1);
+            await _userLanguageRepository.AddAsync(language2);
+            await _userLanguageRepository.AddAsync(language3);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userLanguageRepository.CountNativeLanguages(user.Id);
+
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public async Task CountNonNativeLanguages_ShouldReturnCorrectCount()
+        {
+            var user = await CreateTestUser();
+            var language1 = CreateUserLanguage(user.Id, "en", ProficiencyLevel.Native);
+            var language2 = CreateUserLanguage(user.Id, "es", ProficiencyLevel.Intermediate);
+            var language3 = CreateUserLanguage(user.Id, "pt", ProficiencyLevel.Beginner);
+            await _userLanguageRepository.AddAsync(language1);
+            await _userLanguageRepository.AddAsync(language2);
+            await _userLanguageRepository.AddAsync(language3);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userLanguageRepository.CountNonNativeLanguages(user.Id);
+
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public async Task HasNativeLanguage_WithNativeLanguage_ShouldReturnTrue()
+        {
+            var user = await CreateTestUser();
+            var language = CreateUserLanguage(user.Id, "en", ProficiencyLevel.Native);
+            await _userLanguageRepository.AddAsync(language);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userLanguageRepository.HasNativeLanguage(user.Id);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task HasNativeLanguage_WithoutNativeLanguage_ShouldReturnFalse()
+        {
+            var user = await CreateTestUser();
+            var language = CreateUserLanguage(user.Id, "en", ProficiencyLevel.Intermediate);
+            await _userLanguageRepository.AddAsync(language);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userLanguageRepository.HasNativeLanguage(user.Id);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task HasNonNativeLanguage_WithNonNativeLanguage_ShouldReturnTrue()
+        {
+            var user = await CreateTestUser();
+            var language = CreateUserLanguage(user.Id, "en", ProficiencyLevel.Intermediate);
+            await _userLanguageRepository.AddAsync(language);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userLanguageRepository.HasNonNativeLanguage(user.Id);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task HasNonNativeLanguage_WithoutNonNativeLanguage_ShouldReturnFalse()
+        {
+            var user = await CreateTestUser();
+            var language = CreateUserLanguage(user.Id, "en", ProficiencyLevel.Native);
+            await _userLanguageRepository.AddAsync(language);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userLanguageRepository.HasNonNativeLanguage(user.Id);
+
+            Assert.False(result);
+        }
+    }
+} 

--- a/src/Spoksy.Test/Infrastructure/Repositories/UserRepositoryTests.cs
+++ b/src/Spoksy.Test/Infrastructure/Repositories/UserRepositoryTests.cs
@@ -1,0 +1,70 @@
+using Spoksy.Domain.Entities;
+using Spoksy.Domain.ValueObjects;
+using Spoksy.Domain.Contracts;
+using Spoksy.Infrastructure.Repositories;
+
+namespace Spoksy.Test.Infrastructure.Repositories
+{
+    public class UserRepositoryTests : IntegrationTestBase
+    {
+        private readonly IUserRepository _userRepository;
+
+        public UserRepositoryTests() : base()
+        {
+            _userRepository = new UserRepository(_context);
+        }
+
+        private User CreateValidUser(string name = "Test User", string email = "test@example.com")
+        {
+            return new User(
+                name,
+                email,
+                DateTime.UtcNow.AddYears(-25),
+                Country.GetByCode("BR")
+            );
+        }
+
+        [Fact]
+        public async Task GetByEmailAsync_WithExistingEmail_ShouldReturnUser()
+        {
+            var user = CreateValidUser();
+            await _userRepository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userRepository.GetByEmailAsync(user.Email);
+
+            Assert.NotNull(result);
+            Assert.Equal(user.Email, result.Email);
+        }
+
+        [Fact]
+        public async Task GetByEmailAsync_WithNonExistingEmail_ShouldReturnNull()
+        {
+            var result = await _userRepository.GetByEmailAsync("teste@email.com");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task IsEmailUniqueAsync_WithUniqueEmail_ShouldReturnTrue()
+        {
+            var uniqueEmail = "unique@example.com";
+
+            var result = await _userRepository.IsEmailUniqueAsync(uniqueEmail);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsEmailUniqueAsync_WithExistingEmail_ShouldReturnFalse()
+        {
+            var user = CreateValidUser();
+            await _userRepository.AddAsync(user);
+            await _unitOfWork.CommitAsync();
+
+            var result = await _userRepository.IsEmailUniqueAsync(user.Email);
+
+            Assert.False(result);
+        }
+    }
+}

--- a/src/Spoksy.Test/Spoksy.Test.csproj
+++ b/src/Spoksy.Test/Spoksy.Test.csproj
@@ -5,10 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
@@ -20,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Spoksy.Application\Spoksy.Application.csproj" />
+    <ProjectReference Include="..\Spoksy.Infrastructure\Spoksy.Infrastructure.csproj" />
     <ProjectReference Include="..\Spoksy.Domain\Spoksy.Domain.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Description

This pull request adds database configuration, repository implementations, and integration tests to the project. It introduces PostgreSQL connection setup in `Program.cs` and Dependency Injection. It also includes entity configurations, the implementation of the Unit of Work pattern, and async repositories such as `IChatRepository` and `IChatParticipantRepository`.

Additionally, the `Spoksy.Infrastructure.csproj` and `Spoksy.Test.csproj` files are updated with Entity Framework Core and Npgsql dependencies. Integration tests are created using `IntegrationTestBase` with an in-memory SQLite database to ensure the correctness of the repository implementations.


Fixes # (issue)

N/A — Initial implementation for infrastructure

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  

---

# How Has This Been Tested?

This has been tested through automated integration tests that validate the behavior of the repository implementations with an in-memory SQLite database. The tests cover scenarios such as entity persistence, retrieval, and the behavior of the Unit of Work pattern.

**Test Configuration**:  
* .NET version: 9.0.202
* OS: Windows
* Toolchain: Visual Studio xUnit
* SDK: 9.0.202

---

# Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
- [x] Any dependent changes have been merged and published in downstream modules